### PR TITLE
Make sure videos are aligned to their set offsets on playback

### DIFF
--- a/views/record.hbs
+++ b/views/record.hbs
@@ -178,7 +178,7 @@
             function pauseTheRecordedVideos(){
 
                 Array.from(leadView.querySelectorAll('video')).forEach(function(video){
-                    video.currentTime = 0;
+                    video.currentTime = Number(video.dataset.offset / 1000) || 0;
                     video.pause();
                 });
 
@@ -463,7 +463,7 @@
                 }
 
                 recordedVideo.dataset.active = "true";
-                recordedVideo.currentTime = 0;
+                recordedVideo.currentTime = streamOffset / 1000;
 
                 playbackBtn.dataset.active = "true";
                 saveBtn.dataset.active = "true";
@@ -496,7 +496,7 @@
                 recordedVideo.pause()
                 recordedVideos.pause();
 
-                recordedVideo.currentTime = 0;
+                recordedVideo.currentTime = streamOffset / 1000;
 
             }
 


### PR DESCRIPTION
A report came in that the videos that people play with weren't aligned with each other despite syncing perfectly in the final render process.

This PR patches the issue, and works to alleviate the stream offset on the client-side.